### PR TITLE
[Incomplete] Support for docstring rules

### DIFF
--- a/src/test/__snapshots__/parser.test.ts.snap
+++ b/src/test/__snapshots__/parser.test.ts.snap
@@ -67,6 +67,46 @@ Object {
 }
 `;
 
+exports[`Parser should parse a feature with docstring 1`] = `
+Object {
+  "annotations": Array [],
+  "background": null,
+  "name": Object {
+    "location": Object {
+      "column": 9,
+      "line": 1,
+      "offset": 8,
+    },
+    "value": "doc strings",
+  },
+  "scenarios": Array [
+    Object {
+      "annotations": Array [],
+      "name": Object {
+        "location": Object {
+          "column": 12,
+          "line": 2,
+          "offset": 32,
+        },
+        "value": "doc strings",
+      },
+      "rules": Array [
+        Object {
+          "docstring": "I have a line.
+And another line.",
+          "location": Object {
+            "column": 10,
+            "line": 3,
+            "offset": 54,
+          },
+          "value": "I have a docstring",
+        },
+      ],
+    },
+  ],
+}
+`;
+
 exports[`Parser should parse a feature with no newline at the end of the file 1`] = `
 Object {
   "annotations": Array [],

--- a/src/test/doc-string.feature
+++ b/src/test/doc-string.feature
@@ -1,0 +1,7 @@
+Feature: doc strings
+  Scenario: doc strings
+    Given I have a docstring
+      """
+      I have a line.
+      And another line.
+      """

--- a/src/test/parser.test.ts
+++ b/src/test/parser.test.ts
@@ -21,6 +21,10 @@ describe("Parser", () => {
     const result = parse(readFileSync(__dirname + '/data-table.feature', 'utf8'));
     expect(result).toMatchSnapshot();
   });
+  it("should parse a feature with docstring", () => {
+    const result = parse(readFileSync(__dirname + '/doc-string.feature', 'utf8'));
+    expect(result).toMatchSnapshot();
+  });
 
   it("should parse a feature with a background", () => {
     const result = parse(readFileSync(__dirname + '/background.feature', 'utf8'));


### PR DESCRIPTION
Heya, I thought I'd be able to make you a nice ready-to-go PR for this, but alas, I won't be able to work on this further. 

This adds parser support for the docstring syntax supported by the official parser - described here:
https://cucumber.io/docs/reference#doc-strings

I believe the parser addition is sound (tests included) but I didn't have a chance to figure out how to properly forward it to the step definition handler. It should just be the last arg of the callback, same as table (but without being wrapped in anything - the raw string without indents will suffice IMO). 

As-is it's available on the parsed Rule object under the key `docstring` (instead of `table`, basically). 

Hope you  find this useful!