### PR TITLE
Only require cucumber if it doesn't exist already

### DIFF
--- a/src/generic-transformer.ts
+++ b/src/generic-transformer.ts
@@ -32,7 +32,7 @@ export default class GenericTransformer extends Transformer<any> {
       getFeatureName: (feature: Feature) => 'Feature: ' + feature.name.value,
       getScenarioName: (feature: Feature, scenario: Scenario) =>
         scenario.name.value,
-      preamble: `const {cucumber} = require("stucumber");
+      preamble: `if (!global.cucumber) { const {cucumber} = require("stucumber"); }
          const promiseFinally = require('promise.prototype.finally');
          const _cucumber = cucumber.clone();`,
       ...options

--- a/test/__snapshots__/generic-transformer.test.ts.snap
+++ b/test/__snapshots__/generic-transformer.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`transformer should transform the AST ava style 1`] = `
-"const {cucumber} = require(\\"stucumber\\");
+"if (!global.cucumber) { const {cucumber} = require(\\"stucumber\\"); }
          const promiseFinally = require('promise.prototype.finally');
          const _cucumber = cucumber.clone();const feature = {\\"name\\":\\"background steps\\",\\"annotations\\":[],\\"meta\\":{}, \\"filename\\": __filename};test.before(() => {_cucumber.enterFeature(feature);
       });test.after(() => _cucumber.exitFeature(feature));test(\\"background steps > this is a test\\", () => {const world = _cucumber.createWorld();const scenario = {\\"name\\":\\"this is a test\\",\\"annotations\\":[],\\"meta\\":{}, \\"feature\\": feature, \\"steps\\": [{\\"name\\":\\"something\\",\\"line\\":8,\\"keyword\\":\\"Given\\"}]};return promiseFinally(_cucumber.enterScenario(world, scenario).then(() => _cucumber.rule(world, \\"a thing\\", null)).then(() => _cucumber.rule(world, \\"I do a thing\\", null)).then(() => _cucumber.rule(world, \\"something happens\\", null)).then(() => _cucumber.rule(world, \\"something\\", null)), () => _cucumber.exitScenario(world, scenario));});
@@ -9,7 +9,7 @@ exports[`transformer should transform the AST ava style 1`] = `
 `;
 
 exports[`transformer should transform the AST jest-style 1`] = `
-"const {cucumber} = require(\\"stucumber\\");
+"if (!global.cucumber) { const {cucumber} = require(\\"stucumber\\"); }
          const promiseFinally = require('promise.prototype.finally');
          const _cucumber = cucumber.clone();describe(\\"Feature: test feature\\", () => {const feature = {\\"name\\":\\"test feature\\",\\"annotations\\":[],\\"meta\\":{}, \\"filename\\": __filename};beforeAll(() => {_cucumber.defineRule(\\"foo bar\\", (world, params) => Promise.resolve().then(() => _cucumber.rule(world, \\"test rule\\", null, params)));_cucumber.enterFeature(feature);
       });afterAll(() => _cucumber.exitFeature(feature));it(\\"test scenario\\", () => {const world = _cucumber.createWorld();const scenario = {\\"name\\":\\"test scenario\\",\\"annotations\\":[],\\"meta\\":{}, \\"feature\\": feature, \\"steps\\": [{\\"name\\":\\"test rule\\",\\"line\\":4,\\"keyword\\":\\"\\"},{\\"name\\":\\"test rule 2\\",\\"line\\":5,\\"keyword\\":\\"\\"}]};return promiseFinally(_cucumber.enterScenario(world, scenario).then(() => _cucumber.rule(world, \\"background\\", null)).then(() => _cucumber.rule(world, \\"test rule\\", null)).then(() => _cucumber.rule(world, \\"test rule 2\\", null)), () => _cucumber.exitScenario(world, scenario));});});


### PR DESCRIPTION
Firstly, thanks for this and the gherkin-jest project. It's very much appreciated 👍 

This PR just changes the `GenericTransformer`, so it only includes the `stucumber` package if there is no global variable already set. This will allow us to set cucumber as a global variable inside of the testing framework, and use that for the tests. This change shouldn't break existing functionality (to the best of my knowledge).

I've stumbled into this issue when using Jest (and gherkin-jest) and trying to set up cucumber as a global variable. The cucumber instance in `setupFiles` is then different from the one generated by gherkin-jest/stucumber, so the tests won't pass.